### PR TITLE
network.py line1 updated

### DIFF
--- a/GithubMobile/network.py
+++ b/GithubMobile/network.py
@@ -1,5 +1,4 @@
-from httplib import (HTTPSConnection,
-                                  HTTPException)
+from httplib import HTTPSConnection,HTTPException
 from simon816 import json
 from base64 import encodestring
 class Connection:


### PR DESCRIPTION
error in 1st line  corrected.
from x import (y,z) does not work on PyS60.
so,correct working syntax is:
from x import y,z
